### PR TITLE
Fix names and refine code

### DIFF
--- a/src/avl.zig
+++ b/src/avl.zig
@@ -2,23 +2,23 @@
 //https://www.geeksforgeeks.org/c/c-program-to-implement-avl-tree/
 //
 
-pub fn Node(ty: type) type {
+pub fn Node(Ty: type) type {
     return struct {
         key: u32,
-        data: ty,
+        data: Ty,
         left: i32,
         right: i32,
         height: i32,
     };
 }
-pub fn AVL(comptime max_len: usize, ty: type) type {
+pub fn AVL(comptime max_len: usize, Ty: type) type {
     return struct {
         len: i32 = 0,
-        nodes: [max_len]Node(ty) = undefined,
+        nodes: [max_len]Node(Ty) = undefined,
 
         const Self = @This();
 
-        pub fn search(self: *const Self, root: i32, key: u32) ?ty {
+        pub fn search(self: *const Self, root: i32, key: u32) ?Ty {
             if (root == -1) return null;
             const node = self.nodes[@as(usize, @intCast(root))];
             if (key == node.key) return node.data;
@@ -26,7 +26,7 @@ pub fn AVL(comptime max_len: usize, ty: type) type {
             if (key > node.key) return self.search(node.right, key);
             return null;
         }
-        pub fn insert(self: *Self, node: i32, key: u32, data: ty) i32 {
+        pub fn insert(self: *Self, node: i32, key: u32, data: Ty) i32 {
             // 1. Perform standard BST insertion
             if (node == -1) return self.createNode(key, data);
 
@@ -78,7 +78,7 @@ pub fn AVL(comptime max_len: usize, ty: type) type {
             return node;
         }
 
-        fn access(self: *Self, i: i32) *(Node(ty)) {
+        fn access(self: *Self, i: i32) *(Node(Ty)) {
             return &self.nodes[@as(usize, @intCast(i))];
         }
 
@@ -95,7 +95,7 @@ pub fn AVL(comptime max_len: usize, ty: type) type {
         // Function to create a new node
         //     node->height = 1; // New node is initially added at leaf
 
-        fn createNode(self: *Self, key: u32, data: ty) i32 {
+        fn createNode(self: *Self, key: u32, data: Ty) i32 {
             const curr = self.len;
             if (curr >= self.nodes.len) unreachable; //The used state exceeds the estimated maximum. You should increase the value of max_len
             self.len += 1;
@@ -113,11 +113,11 @@ pub fn AVL(comptime max_len: usize, ty: type) type {
         fn rightRotate(self: *Self, y: i32) i32 {
             // Right rotation function
             const x = self.access(y).left;
-            const T2 = self.access(x).right;
+            const t2 = self.access(x).right;
 
             // Perform rotation
             self.access(x).right = y;
-            self.access(y).left = T2;
+            self.access(y).left = t2;
 
             // Update heights
             self.access(y).height = @max(
@@ -136,12 +136,12 @@ pub fn AVL(comptime max_len: usize, ty: type) type {
         fn leftRotate(self: *Self, x: i32) i32 {
             // Left rotation function
             const y = self.access(x).right;
-            const T2 = self.access(y).left;
+            const t2 = self.access(y).left;
 
             // Perform rotation
             self.access(y).left = x;
             //     x->right = T2;
-            self.access(x).right = T2;
+            self.access(x).right = t2;
 
             // Update heights
 
@@ -180,23 +180,23 @@ test "avl" {
     const ty_arr: []const type = &.{ i32, i64, u32, u64 };
     const len_arr: []const usize = &.{ 0, 1, 2, 3, 4, 6, 8, 10, 200, 450, 780, 800, 1000 };
 
-    inline for (ty_arr) |ty| {
+    inline for (ty_arr) |Ty| {
         inline for (len_arr) |len| {
-            var tmp_arr: [len]struct { u32, ty } = undefined;
+            var tmp_arr: [len]struct { u32, Ty } = undefined;
             for (0..len) |i| {
-                tmp_arr[i] = .{ @as(u32, @intCast(i)), @as(ty, @intCast(i + 1)) };
+                tmp_arr[i] = .{ @as(u32, @intCast(i)), @as(Ty, @intCast(i + 1)) };
             }
 
             for (0..len) |_| {
-                const id_a: usize = @intCast(rand.intRangeAtMost(ty, 0, len - 1));
-                const id_b: usize = @intCast(rand.intRangeAtMost(ty, 0, len - 1));
+                const id_a: usize = @intCast(rand.intRangeAtMost(Ty, 0, len - 1));
+                const id_b: usize = @intCast(rand.intRangeAtMost(Ty, 0, len - 1));
                 const tmp = tmp_arr[id_a];
                 tmp_arr[id_a] = tmp_arr[id_b];
                 tmp_arr[id_b] = tmp;
             }
 
             var root: i32 = -1;
-            var avl: AVL(len, ty) = .{};
+            var avl: AVL(len, Ty) = .{};
 
             for (0..len) |i| {
                 const tmp = tmp_arr[i];

--- a/src/polystate.zig
+++ b/src/polystate.zig
@@ -9,7 +9,7 @@ pub const Exit = union(enum) {};
 // FsmState  : type           , Example(A), Example(B)
 
 pub const Mode = enum {
-    no_suspendable,
+    not_suspendable,
     suspendable,
 };
 
@@ -27,7 +27,7 @@ pub fn FSM(
     comptime Context_: type,
     // enter_fn args type is State
     comptime enter_fn_: ?fn (*Context_, type) void,
-    comptime transition_method_: if (mode_ == .no_suspendable) void else Method,
+    comptime transition_method_: if (mode_ == .not_suspendable) void else Method,
     comptime State_: type,
 ) type {
     return struct {
@@ -35,7 +35,7 @@ pub fn FSM(
         pub const mode = mode_;
         pub const Context = Context_;
         pub const enter_fn = enter_fn_;
-        pub const transition_method: Method = if (mode_ == .no_suspendable) .current else transition_method_;
+        pub const transition_method: Method = if (mode_ == .not_suspendable) .current else transition_method_;
         pub const State = State_;
     };
 }
@@ -145,7 +145,7 @@ pub fn Runner(
         pub const RetType =
             switch (FsmState.mode) {
                 .suspendable => ?StateId,
-                .no_suspendable => void,
+                .not_suspendable => void,
             };
 
         pub fn idFromState(comptime State: type) StateId {
@@ -172,7 +172,7 @@ pub fn Runner(
                     if (State == Exit) {
                         return switch (FsmState.mode) {
                             .suspendable => null,
-                            .no_suspendable => {},
+                            .not_suspendable => {},
                         };
                     }
 
@@ -223,7 +223,7 @@ pub const Graph = struct {
 
     pub const init: Self = .{
         .name = "",
-        .mode = .no_suspendable,
+        .mode = .not_suspendable,
         .node_set = .empty,
         .edge_array_list = .empty,
     };
@@ -367,9 +367,9 @@ pub const Graph = struct {
                         const edge_label = field.name;
                         const NextFsmState = field.type;
                         const NextState = NextFsmState.State;
-                        const method_val = if (NextFsmState.mode == .no_suspendable) null else NextFsmState.transition_method;
+                        const method_val = if (NextFsmState.mode == .not_suspendable) null else NextFsmState.transition_method;
 
-                        if (graph.mode == .no_suspendable) {
+                        if (graph.mode == .not_suspendable) {
                             graph.insertEdge(gpa, State, NextState, null, edge_label) catch unreachable;
                         } else {
                             graph.insertEdge(gpa, State, NextState, method_val, edge_label) catch unreachable;

--- a/src/polystate.zig
+++ b/src/polystate.zig
@@ -92,6 +92,10 @@ pub fn StateMap(comptime max_len: usize) type {
         }
 
         pub fn idFromState(comptime self: *const Self, comptime State: type) self.StateId {
+            if (!@hasField(self.StateId, @typeName(State))) @compileError(std.fmt.comptimePrint(
+                "Can't find State {s}",
+                .{@typeName(State)},
+            ));
             return @field(self.StateId, @typeName(State));
         }
 

--- a/src/polystate.zig
+++ b/src/polystate.zig
@@ -23,12 +23,12 @@ pub const Method = enum {
 
 pub fn FSM(
     comptime name_: []const u8,
-    mode_: Mode,
-    Context_: type,
+    comptime mode_: Mode,
+    comptime Context_: type,
     // enter_fn args type is State
-    enter_fn_: ?fn (*Context_, type) void,
-    transition_method_: if (mode_ == .no_suspendable) void else Method,
-    State_: type,
+    comptime enter_fn_: ?fn (*Context_, type) void,
+    comptime transition_method_: if (mode_ == .no_suspendable) void else Method,
+    comptime State_: type,
 ) type {
     return struct {
         pub const name = name_;
@@ -40,7 +40,7 @@ pub fn FSM(
     };
 }
 
-pub fn StateMap(max_len: usize) type {
+pub fn StateMap(comptime max_len: usize) type {
     return struct {
         root: i32 = -1,
         avl: AVL(max_len, struct { type, usize }) = .{}, // the type is State
@@ -87,11 +87,11 @@ pub fn StateMap(max_len: usize) type {
             }
         }
 
-        pub fn StateFromId(comptime self: *const Self, state_id: self.StateId) type {
+        pub fn StateFromId(comptime self: *const Self, comptime state_id: self.StateId) type {
             return self.avl.nodes[@intFromEnum(state_id)].data[0];
         }
 
-        pub fn idFromState(comptime self: *const Self, State: type) self.StateId {
+        pub fn idFromState(comptime self: *const Self, comptime State: type) self.StateId {
             return @field(self.StateId, @typeName(State));
         }
 
@@ -105,7 +105,7 @@ pub fn StateMap(max_len: usize) type {
             }
         }
 
-        fn collect(self: *Self, FsmState: type) void {
+        fn collect(comptime self: *Self, comptime FsmState: type) void {
             const State = FsmState.State;
             const state_hash = Adler32.hash(@typeName(State));
             const name = FsmState.name;
@@ -133,7 +133,11 @@ pub fn StateMap(max_len: usize) type {
     };
 }
 
-pub fn Runner(max_len: usize, is_inline: bool, FsmState: type) type {
+pub fn Runner(
+    comptime max_len: usize,
+    comptime is_inline: bool,
+    comptime FsmState: type,
+) type {
     return struct {
         pub const Context = FsmState.Context;
         pub const state_map: StateMap(max_len) = .init(FsmState);


### PR DESCRIPTION
Main changes in this PR:
- Fixed incorrect name casing.
- Renamed `no_suspendable` to `not_suspendable`.
- Renamed `stateToId` to `idFromState` (it's more common to use 'from' over 'to' in Zig).
- Changed `StateId` to be an enum instead of an integer, making it fully type-safe (all possible values of `StateId` represent a valid state).
- Consolidated more logic into `StateMap`, and made the usage of `StateMap` more straightforward.